### PR TITLE
Allow the map to not overwrite properties that are already set.

### DIFF
--- a/Mapper/AbstractMap.php
+++ b/Mapper/AbstractMap.php
@@ -17,6 +17,7 @@ abstract class AbstractMap implements MapInterface
     
     protected $fieldAccessors = array();
     protected $fieldFilters = array();
+    protected $overwriteIfSet = true;
 
     /**
      * Associate a member to another member given their property pathes.
@@ -60,6 +61,27 @@ abstract class AbstractMap implements MapInterface
     }
 
     /**
+     * Sets whether to overwrite the destination value if it is already set.
+     *
+     * @param $value
+     * @return AbstractMap
+     */
+    public function setOverwriteIfSet($value)
+    {
+        $this->overwriteIfSet = (bool) $value;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getOverwriteIfSet()
+    {
+        return $this->overwriteIfSet;
+    }
+
+    /**
      * Builds the default map using property names.
      * 
      * @return AbstractMap 
@@ -75,18 +97,18 @@ abstract class AbstractMap implements MapInterface
         return $this;
     }
 
-	/**
-	 * Ignore the destination field.
-	 *
-	 * @param string $destinationMember
-	 * @return AbstractMap
-	 */
-	public function ignoreMember($destinationMember)
-	{
-		unset($this->fieldAccessors[$destinationMember]);
+    /**
+     * Ignore the destination field.
+     *
+     * @param string $destinationMember
+     * @return AbstractMap
+     */
+    public function ignoreMember($destinationMember)
+    {
+        unset($this->fieldAccessors[$destinationMember]);
 
-		return $this;
-	}
+        return $this;
+    }
 
     /**
      * {@inheritDoc}

--- a/Mapper/Mapper.php
+++ b/Mapper/Mapper.php
@@ -79,7 +79,18 @@ class Mapper
             }
             
             $propertyPath = new PropertyPath($path);
-            $propertyPath->setValue($destination, $value);
+
+            if ($map->getOverwriteIfSet())
+            {
+                $propertyPath->setValue($destination, $value);
+            }
+            else
+            {
+                if ($propertyPath->getValue($destination) == null)
+                {
+                    $propertyPath->setValue($destination, $value);
+                }
+            }
         }
         
         return $destination;

--- a/README.markdown
+++ b/README.markdown
@@ -319,3 +319,28 @@ $mapper->map($source, $destination);
 
 var_dump(destination->description); // ignored, will be null
 ```
+
+## Do not overwrite already set field
+
+You can have the mapper not overwrite a field that is set on the destination.
+
+``` php
+<?php
+
+// get mapper
+$mapper = $container->get('bcc_auto_mapper.mapper');
+// create default map
+$mapper->createMap('My\SourcePost', 'My\DestinationPost')
+    ->setOverwriteIfSet(false);
+
+// create objects
+$source = new SourcePost();
+$source->description = 'Symfony2 developer';
+$destination = new DestinationPost();
+$destination->description = 'Foo bar';
+
+// map
+$mapper->map($source, $destination);
+
+var_dump(destination->description); // will be 'Foo bar'
+```

--- a/Tests/Mapper/MapperTest.php
+++ b/Tests/Mapper/MapperTest.php
@@ -132,14 +132,14 @@ class MapperTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('Michel', $destination->title);
     }
 
-	public function testIgnoreField() {
-		// ARRANGE
+    public function testIgnoreField() {
+        // ARRANGE
         $source = new SourcePost();
         $source->description = 'Symfony2 developer';
         $destination = new PrivateDestinationPost();
         $mapper = new Mapper();
         $mapper->createMap('BCC\AutoMapperBundle\Tests\Fixtures\SourcePost', 'BCC\AutoMapperBundle\Tests\Fixtures\PrivateDestinationPost')
-			->ignoreMember('id');
+            ->ignoreMember('id');
 
         // ACT
         try {
@@ -149,6 +149,41 @@ class MapperTest extends \PHPUnit_Framework_TestCase {
         }
 
         // ASSERT
-		$this->assertNull($destination->getId());
-	}
+        $this->assertNull($destination->getId());
+    }
+
+    public function testOverwrittenIfSet() {
+        $source = new SourcePost();
+        $source->description = 'Symfony2 developer';
+        $destination = new DestinationPost();
+        $destination->description = 'Foo bar';
+        $mapper = new Mapper();
+        $mapper->createMap('BCC\AutoMapperBundle\Tests\Fixtures\SourcePost', 'BCC\AutoMapperBundle\Tests\Fixtures\DestinationPost');
+
+        try {
+            $mapper->map($source, $destination);
+        } catch (\Exception $e) {
+            $this->fail('should not catch an exception - ' . $e->getMessage());
+        }
+
+        $this->assertEquals('Symfony2 developer', $destination->description);
+    }
+
+    public function testNotOverwrittenIfSet() {
+        $source = new SourcePost();
+        $source->description = 'Symfony2 developer';
+        $destination = new DestinationPost();
+        $destination->description = 'Foo bar';
+        $mapper = new Mapper();
+        $mapper->createMap('BCC\AutoMapperBundle\Tests\Fixtures\SourcePost', 'BCC\AutoMapperBundle\Tests\Fixtures\DestinationPost')
+            ->setOverwriteIfSet(false);
+
+        try {
+            $mapper->map($source, $destination);
+        } catch (\Exception $e) {
+            $this->fail('should not catch an exception - ' . $e->getMessage());
+        }
+
+        $this->assertEquals('Foo bar', $destination->description);
+    }
 }


### PR DESCRIPTION
Was a little piece of useful functionality in a situation where we already had a semi-populated object and wanted to copy over any values that hadn't already been set.
