### PR TITLE
Fix composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": ">=2.2.0,<3.0",
-        "symfony/form": ">=2.2.0,<3.0"
+        "symfony/property-access": ">=2.2.0,<3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"


### PR DESCRIPTION
Minor little fix for the dependencies so that they're correct. The original symfony/form dependency was what was required before, but it should now be just the property-access component.
