### PR TITLE
Type guessing

### DIFF
--- a/Mapper/Mapper.php
+++ b/Mapper/Mapper.php
@@ -67,7 +67,8 @@ class Mapper
     {
         $map = $this->getMap(
             $this->guessType($source),
-            $this->guessType($destination);
+            $this->guessType($destination)
+        );
         $fieldAccessors = $map->getFieldAccessors();
         $fieldFilters = $map->getFieldFilters();
         


### PR DESCRIPTION
There is an issue when you pass Doctrine2 entity to mapper. 
The type of entity can be Proxies__CG__\Your\Namespace, whereas we have map for Your\Namespace only.
